### PR TITLE
Fix code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/internal/api/handlers/landmark_handler.go
+++ b/internal/api/handlers/landmark_handler.go
@@ -219,8 +219,22 @@ func applyFilters(query *gorm.DB, filters map[string]string) *gorm.DB {
 }
 
 func applySorting(query *gorm.DB, sortBy, sortOrder string) *gorm.DB {
-	if sortBy != "" {
+	allowedSortBy := map[string]bool{
+		"name": true,
+		"date": true,
+		// Add other allowed column names here
+	}
+
+	allowedSortOrder := map[string]bool{
+		"asc":  true,
+		"desc": true,
+	}
+
+	if allowedSortBy[sortBy] && allowedSortOrder[sortOrder] {
 		query = query.Order(fmt.Sprintf("%s %s", sortBy, sortOrder))
+	} else {
+		// Handle invalid sortBy or sortOrder, e.g., set default or return an error
+		query = query.Order("name asc") // Default sorting
 	}
 	return query
 }

--- a/internal/api/handlers/landmark_handler.go
+++ b/internal/api/handlers/landmark_handler.go
@@ -220,9 +220,9 @@ func applyFilters(query *gorm.DB, filters map[string]string) *gorm.DB {
 
 func applySorting(query *gorm.DB, sortBy, sortOrder string) *gorm.DB {
 	allowedSortBy := map[string]bool{
-		"name": true,
-		"date": true,
-		// Add other allowed column names here
+		"name":    true,
+		"city":    true,
+		"country": true,
 	}
 
 	allowedSortOrder := map[string]bool{


### PR DESCRIPTION
Fixes [https://github.com/Gravgor/landmark-api/security/code-scanning/1](https://github.com/Gravgor/landmark-api/security/code-scanning/1)

To fix the problem, we should avoid directly embedding user-provided values into the SQL query string. Instead, we should validate and sanitize the `sortBy` and `sortOrder` parameters to ensure they only contain safe values. We can use a whitelist approach to allow only specific column names and sort orders.

1. Define a list of allowed column names and sort orders.
2. Validate the `sortBy` and `sortOrder` parameters against these lists.
3. Construct the SQL query using the validated parameters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
